### PR TITLE
勤怠登録画面の作成

### DIFF
--- a/backend/app/Contact.php
+++ b/backend/app/Contact.php
@@ -15,7 +15,8 @@ class Contact extends Model
     }
 
     #created_atを任意のフォーマットで取得(投稿時間出力用)
-    public function getCreatedAtAttribute($date) {
+    public function getCreatedAtAttribute($date)
+    {
         return Carbon::createFromFormat('Y-m-d H:i:s', $date)->format('H時i分');
     }
 
@@ -32,11 +33,24 @@ class Contact extends Model
         $month    = date("m");              #現在の月を出力する
         $day      = date("d");              #現在の日付を出力する
         $datetime = new DateTime("now");
-        $day_week = array( "日", "月", "火", "水", "木", "金", "土" );
+        $day_week = array("日", "月", "火", "水", "木", "金", "土");
         $week     = $day_week[$datetime->format("w")];
         $time     = date("H:i");
-        $array    = [$year,$month,$day,$week,$time];
+        $array    = [$year, $month, $day, $week, $time];
+        return $array;
+    }
+
+    #共通テンプレートに渡すworkデータの変数
+    public function layout_data()
+    {
+        $year     = date("Y");              #現在の年を出力する
+        $month    = date("m");              #現在の月を出力する
+        $day      = date("d");              #現在の日付を出力する
+        $datetime = new DateTime("now");
+        $day_week = array("日", "月", "火", "水", "木", "金", "土");
+        $week     = $day_week[$datetime->format("w")];
+        $time     = date("H:i");
+        $array    = [$year, $month, $day, $week, $time];
         return $array;
     }
 }
-

--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -93,10 +93,12 @@ class RegisterController extends Controller
             $date = date('w', strtotime($year.$month.$day));      #システム日付の曜日番号が出力(0〜6)
             $day_week=$week[$date];                               #日〜土の値が出力される
 
-            if($day_week == "土" or $day_week == "日"){
-                $work_section_id = 2;
+            if($day_week == "土"){
+                $work_section_id = 3;                             #法定外休日
+            }elseif($day_week == "日") {
+                $work_section_id = 2;                             #法定休日
             }else{
-                $work_section_id = 1;
+                $work_section_id = 1;                             #出勤
             }
 
             if ($user) {
@@ -107,10 +109,10 @@ class RegisterController extends Controller
                 'year' => $year,
                 'month' => $month,
                 'day' => $day,
-                'workstart' => '09:00:00',
-                'workend' => '18:00:00',
-                'breaktime' => '1:00',
-                'total_worktime' => '8:00',
+                'workstart' => '00:00:00',
+                'workend' => '00:00:00',
+                'breaktime' => '00:00:00',
+                'total_worktime' => '00:00:00',
                 'remark' => 'なし',
                 'approval_flg' => '1',
                 'work_section_id' => $work_section_id,

--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Validator;
 use DateTime;                                  #DataTimeクラスの宣言
 use App\Work;                                  #Workクラスの宣言
 use Illuminate\Support\Facades\Auth;           #Authクラスの宣言
+use App\Work_system;                           #Work_systemクラスの宣言
 
 class RegisterController extends Controller
 {
@@ -73,10 +74,17 @@ class RegisterController extends Controller
         $week             = array( "日", "月", "火", "水", "木", "金", "土" );
         $thisMonthLastDay = date('d', strtotime('last day of this month'));     #当月の最後の日付が出力
 
+        $work_system = Work_system::create([
+            'fixed_workstart' => '00:00:00',
+            'fixed_workend' => '00:00:00',
+            'fixed_breaktime' => '01:00:00',
+        ]);
+
         $user = User::create([
             'f_name' => $data['f_name'],
             'r_name' => $data['r_name'],
             'email' => $data['email'],
+            'work_system_id' => $work_system->id,
             'password' => Hash::make($data['password']),
         ]);
 
@@ -91,7 +99,6 @@ class RegisterController extends Controller
                 $work_section_id = 1;
             }
 
-
             if ($user) {
                 $user->id;
             }
@@ -100,8 +107,8 @@ class RegisterController extends Controller
                 'year' => $year,
                 'month' => $month,
                 'day' => $day,
-                'workstart' => '00:00:00',
-                'workend' => '00:00:00',
+                'workstart' => '09:00:00',
+                'workend' => '18:00:00',
                 'breaktime' => '1:00',
                 'total_worktime' => '8:00',
                 'remark' => 'なし',
@@ -111,11 +118,6 @@ class RegisterController extends Controller
             ]);
         }
         return $user;
-
-
-
-
-
         // return User::create([
         //     'f_name' => $data['f_name'],
         //     'r_name' => $data['r_name'],

--- a/backend/app/Http/Controllers/ContactController.php
+++ b/backend/app/Http/Controllers/ContactController.php
@@ -62,7 +62,7 @@ class ContactController extends Controller
             'subject' => ['required'],
             'body'    => ['required'],
         ]);
-        $user             = \Auth::user();
+        $user             = Auth::user();
         $contact          = new Contact;
         $contact->year    =request('year');
         $contact->month   =request('month');
@@ -82,7 +82,7 @@ class ContactController extends Controller
      */
     public function show($id)
     {
-        $user= \Auth::user();
+        $user= Auth::user();
         $contact_id = Contact::find($id);
         $contact    = new Contact;
         $today_date = $contact->date();

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -1,12 +1,13 @@
 <?php
 
 namespace App\Http\Controllers;
-
 use App\Work;
 use Illuminate\Http\Request;
-use App\Contact;                        #モデルクラスの宣言
-use Illuminate\Support\Facades\Auth;    #ユーザークラスの宣言
-use DB;
+use App\Contact;                        #連絡事項クラスの宣言
+use App\User;                           #ユーザーモデルの宣言
+use Illuminate\Support\Facades\Auth;    #ユーザークラス(Auth)の宣言
+use DateTime;                           #DataTimeクラスの宣言
+use Carbon\Carbon;                      #日時操作ライブラリの宣言
 
 class WorkController extends Controller
 {
@@ -17,27 +18,21 @@ class WorkController extends Controller
      */
     public function index()
     {
+        $contact = new Contact;
+        $date = $contact->layout_data();
         $login_user_id = Auth::id();
-        $contact    = new Contact;
-        $today_date = $contact->date();
-        $year = $today_date[0];
-        $month = $today_date[1];
-        $day = $today_date[2];
-        $work_date = DB::table('works') ->select('year', 'month', 'day')
-                                        ->where('user_id', '=', $login_user_id)
-                                        ->orWhereYear('year','=', $year)
-                                        ->orWhereMonth('month','=', $month)
-                                        ->orWhereDay('day','=', $day)
-                                        ->get();
+        $user_works  = Work::with('work_section')
+            ->select('*')
+            ->where('user_id', '=', $login_user_id)
+            ->get();
 
-                                        // $query->where(function ($query) {
-                                        //     $query->whereNull('A')
-                                        //         ->orWhere('A', '0');
-                                        // })
-                                        // ->where(function ($query) {
-                                        //     $query->whereNull('B')
-                                        //         ->orWhere('B', '0');
-                                        // })
+        // 勤怠レコード取れなかった場合、例外処理
+        if ($user_works == null) {
+            $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
+            return view('errer', ['errer_messege' => $errer_messege]);
+        }
+
+        return view('works.index', ['user_works' => $user_works,'date' => $date]);
     }
 
     /**
@@ -88,36 +83,52 @@ class WorkController extends Controller
                 $today_date = $contact->date();
                 $year = $today_date[0];
                 $query
-                    ->Where('year','=', $year);
+                    ->Where('year', '=', $year);
             })
             ->where(function ($query) {
                 $contact    = new Contact;
                 $today_date = $contact->date();
                 $month = $today_date[1];
                 $query
-                    ->Where('month','=', $month);
+                    ->Where('month', '=', $month);
             })
             ->where(function ($query) {
                 $contact    = new Contact;
                 $today_date = $contact->date();
                 $day = $today_date[2];
                 $query
-                    ->Where('day','=', $day);
+                    ->Where('day', '=', $day);
             })
             ->get();
 
-
-        if (count($work) == 0){
+        #システム日付取得チェック
+        if (count($work) == 0) {
             $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
-            return view('errer',['errer_messege'=>$errer_messege]);
-        }else{
+            return view('errer', ['errer_messege' => $errer_messege]);
+        } else {
             $work = $work[0];
         }
 
-        #システム日付をインスタンス化
+        #システム設定時間の取得
+        $user = User::with('work_system')
+            ->select('*')
+            ->get();
+
+        #システム設定時間取得チェック
+        if (count($user) == 0) {
+            $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
+            return view('errer', ['errer_messege' => $errer_messege]);
+        }
+
+        #システム日付を取得するために連絡事項クラスをインスタンス化
         $contact    = new Contact;
         $today_date = $contact->date();
-        return view('works.edit',['today_date'=>$today_date,'work'=>$work]);
+        return view('works.edit',
+        [
+            'today_date' => $today_date,
+            'work' => $work,
+            'user' => $user
+        ]);
     }
 
     /**
@@ -130,14 +141,37 @@ class WorkController extends Controller
     public function update(Request $request, $id)
     {
         $work = Work::find($id);
-        if($request->workstart != null){
+        if ($request->workstart != null) {
             $work->workstart = request('workstart');
             $work->save();
-        }else{
+        } elseif($request->workend != null) {
+            #システム設定時間の取得
+            $user = User::with('work_system')
+                ->select('*')
+                ->get();
+
+            #取得した時間をdiffメソッドが使えるフォーマットに変換
+            $fixed_work_end   = new DateTime($user[0]->work_system->fixed_workend);
+            $fixed_work_start = new DateTime($user[0]->work_system->fixed_workstart);
+            $breaktime        = new DateTime($user[0]->work_system->fixed_breaktime);
+
+
+            #働いた時間の計算(時間 = 終了時間-開始時間-休憩時間)
+            $total_time = $fixed_work_end->diff($fixed_work_start);
+            $total_time = $total_time->h.':00';
+            $total_time = new DateTime($total_time);
+            $total_worktime = $total_time->diff($breaktime);
+            $total_worktime = $total_worktime->h.':00';
+
+            #DB更新
+            $work->total_worktime = $total_worktime;
             $work->workend = request('workend');
             $work->save();
+        }else{
+            $errer_messege = "登録に失敗しました。管理者にご連絡ください。";
+            return view('errer', ['errer_messege' => $errer_messege]);
         }
-        return redirect()->route('work.edit',['work'=>$work->id]);
+        return redirect()->route('work.edit', ['work' => $work->id]);
     }
 
     /**

--- a/backend/app/Http/Controllers/WorkSystemController.php
+++ b/backend/app/Http/Controllers/WorkSystemController.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Work_system;
+use Illuminate\Http\Request;
+
+class WorkSystemController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        //
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        //
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(Request $request)
+    {
+        //
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \App\Work_system  $work_system
+     * @return \Illuminate\Http\Response
+     */
+    public function show(Work_system $work_system)
+    {
+        //
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \App\Work_system  $work_system
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(Work_system $work_system)
+    {
+        //
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Work_system  $work_system
+     * @return \Illuminate\Http\Response
+     */
+    public function update(Request $request, Work_system $work_system)
+    {
+        //
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \App\Work_system  $work_system
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(Work_system $work_system)
+    {
+        //
+    }
+}

--- a/backend/app/Http/Controllers/WorkSystemController.php
+++ b/backend/app/Http/Controllers/WorkSystemController.php
@@ -4,6 +4,9 @@ namespace App\Http\Controllers;
 
 use App\Work_system;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;    #ユーザークラス(Auth)の宣言
+use App\User;                           #ユーザーモデルの宣言
+use App\Work;
 
 class WorkSystemController extends Controller
 {
@@ -14,7 +17,19 @@ class WorkSystemController extends Controller
      */
     public function index()
     {
-        //
+        #ユーザーに紐づいているシステム設定を取得
+        // $login_user_id = Auth::id();
+        // $user  = User::with('work_system')
+        // ->select('*')
+        // ->where('id', '=', $login_user_id)
+        // ->get();
+
+        // if ($user == null) {
+        //     $errer_messege = "取得に失敗しました。管理者にご連絡ください。";
+        //     return view('errer', ['errer_messege' => $errer_messege]);
+        // }
+
+        // return view('worksystems.index', ['user' => $user]);
     }
 
     /**

--- a/backend/app/User.php
+++ b/backend/app/User.php
@@ -10,13 +10,19 @@ class User extends Authenticatable
 {
     use Notifiable;
 
+    //リレーションの設定。ユーザーは一つの設定を保持する。
+    public function work_system()
+    {
+        return $this->belongsTo('App\Work_system');
+    }
+
     /**
      * The attributes that are mass assignable.
      *
      * @var array
      */
     protected $fillable = [
-        'f_name','r_name', 'email', 'password',
+        'f_name','r_name', 'email', 'password','work_system_id',
     ];
 
     /**

--- a/backend/app/User.php
+++ b/backend/app/User.php
@@ -9,13 +9,30 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     use Notifiable;
+    #----------------------------------------------------------------
+    #  リレーションの設定
+    #----------------------------------------------------------------
+    # ユーザーは複数の投稿を保持する。
+    public function contacts()
+    {
+        return $this->hasMany('App\Contact');
+    }
 
-    //リレーションの設定。ユーザーは一つの設定を保持する。
+    //ユーザーは一つの勤怠を保持する。
+    public function work()
+    {
+        return $this->belongsTo('App\Work');
+    }
+
+    //ユーザーは一つの勤怠設定を保持する。
     public function work_system()
     {
         return $this->belongsTo('App\Work_system');
     }
 
+    #----------------------------------------------------------------
+    #  ユーザー新規登録時DB登録時の割当許可設定
+    #----------------------------------------------------------------
     /**
      * The attributes that are mass assignable.
      *
@@ -42,4 +59,12 @@ class User extends Authenticatable
     protected $casts = [
         'email_verified_at' => 'datetime',
     ];
+
+    # ----------------------------------------------------------------
+    #  ユーザーに紐づく勤怠を全て取得
+    #----------------------------------------------------------------
+    // public function getworks()
+    // {
+    //     return $this->hasMany('App\Contact');
+    // }
 }

--- a/backend/app/Work.php
+++ b/backend/app/Work.php
@@ -7,13 +7,22 @@ use Illuminate\Database\Eloquent\Model;
 
 class Work extends Model
 {
-    // リレーションの設定。投稿は一つの投稿者に従属する。
+    #----------------------------------------------------------------
+    #  リレーションの設定
+    #----------------------------------------------------------------
+    //ユーザーは一つの勤怠を保持する。
     public function user()
     {
         return $this->hasMany('App\User');
     }
-
-    #ユーザー新規登録時に初期データをcreateする時の割り当て許可設定
+    // 勤怠は一つの出勤区分を保持する。
+    public function work_section()
+    {
+        return $this->belongsTo('App\Work_section');
+    }
+    #----------------------------------------------------------------
+    #  ユーザー新規登録時DB登録時の割当許可設定
+    #----------------------------------------------------------------
     protected $fillable = [
         'year',
         'month',
@@ -27,4 +36,5 @@ class Work extends Model
         'work_section_id',
         'user_id',
     ];
+
 }

--- a/backend/app/Work_section.php
+++ b/backend/app/Work_section.php
@@ -6,5 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class Work_section extends Model
 {
-    //
+    public function works()
+    {
+        return $this->hasMany('App\Work');
+    }
 }

--- a/backend/app/Work_system.php
+++ b/backend/app/Work_system.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class Work_system extends Model
+{
+
+    // リレーションの設定。システムは複数のユーザーに従属する。
+    public function user()
+    {
+        return $this->hasMany('App\User');
+    }
+
+    #ユーザー新規登録時に初期データをcreateする時の割り当て許可設定
+    protected $fillable = [
+        'fixed_workstart',
+        'fixed_workend',
+        'fixed_breaktime',
+    ];
+}

--- a/backend/database/migrations/2020_11_22_105700_create_work_systems_table.php
+++ b/backend/database/migrations/2020_11_22_105700_create_work_systems_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateWorkSystemsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('work_systems', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->time('fixed_workstart')->nullable(false);
+            $table->time('fixed_workend')->nullable(false);
+            $table->time('fixed_breaktime')->nullable(false);
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('work_systems');
+    }
+}

--- a/backend/database/migrations/2020_11_22_113027_add_work_system_users_table.php
+++ b/backend/database/migrations/2020_11_22_113027_add_work_system_users_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddWorkSystemUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->unsignedBigInteger('work_system_id');
+
+            //追加work_system_idに外部キー制約をつける。work_systemsテーブルのidカラムを参照してそのカラムがなくなったらカスケード的に処理する。
+            $table->foreign('work_system_id')
+            ->references('id')
+            ->on('work_systems')
+            ->onDelete('cascade');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('work_system_id');
+        });
+    }
+}

--- a/backend/database/seeds/Work_sectionsTableSeeder.php
+++ b/backend/database/seeds/Work_sectionsTableSeeder.php
@@ -13,9 +13,8 @@ class Work_sectionsTableSeeder extends Seeder
     {
         DB::table('work_sections')->insert([
             ['section_name' => '出勤',],
-            ['section_name' => '公休',],
-            ['section_name' => '有給',],
-            ['section_name' => '欠勤',],
+            ['section_name' => '法定休日',],
+            ['section_name' => '法定外休日',],
         ]);
     }
 }

--- a/backend/public/css/style.css
+++ b/backend/public/css/style.css
@@ -63,3 +63,17 @@ html{
 .attendance .color-gray{
   background-color: #6c757d;
 }
+
+/*
+---------------------------------------------
+勤怠一覧画面
+---------------------------------------------
+*/
+table .work-index_title{
+  background: #e9e1de;
+}
+
+.table .work-sunday{
+  color:#d42f61;
+  background-color:#fbeef2;
+}

--- a/backend/public/js/work-index.js
+++ b/backend/public/js/work-index.js
@@ -1,0 +1,21 @@
+window.addEventListener('load', function () {
+  var work_section = window.document.getElementById('work-section').textContent;
+  var work_section_propaty = document.getElementById('work-section');
+  var count = document.querySelectorAll('tr').length;
+
+
+  for (var i = 0; i < count; i++ ) {
+    var work_section = window.document.getElementById('work-section').textContent;
+    if(work_section == "法定休日"){
+      work_section_propaty.classList.add('work-sunday');
+    }
+
+  }
+
+  // let table = document.getElementById('targetTable');
+  // let cells = table.querySelectorAll('td');
+  // cells.forEach( (cell) =>  console.log(cell.innerHTML));
+
+  // const name = $('#work-targetTable').length;
+  // console.log(name);
+});

--- a/backend/resources/views/layout.blade.php
+++ b/backend/resources/views/layout.blade.php
@@ -18,12 +18,11 @@
       <div class="dropdown">
         <button type="button" class="nav-link btn dropdown-toggle text-white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">勤怠管理</button>
         <div class="dropdown-menu ">
-          <a class="dropdown-item" href="#">勤怠</a>
-          <a class="dropdown-item"  href="#">ご連絡</a>
+          <a class="dropdown-item" href={{ route('work.index') }}>勤怠</a>
         </div>
       </div>
-      <a class='nav-link text-white' href={{route('contact.index')}}>ご連絡一覧</a>
-      <a class='nav-link text-white' href={{route('contact.create')}}>連絡書き込み</a>
+      <a class='nav-link text-white' href={{ route('contact.index') }}>ご連絡一覧</a>
+      <a class='nav-link text-white' href={{ route('contact.create') }}>連絡書き込み</a>
 
       <!-- ここからログインユーザーの表示 -->
       <!-- layouts/app.blade.phpからコピー -->

--- a/backend/resources/views/layouts/works.blade.php
+++ b/backend/resources/views/layouts/works.blade.php
@@ -19,12 +19,12 @@
       <div class="dropdown">
         <button type="button" class="nav-link btn dropdown-toggle text-white" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">勤怠管理</button>
         <div class="dropdown-menu ">
-          <a class="dropdown-item" href="#">勤怠</a>
-          <a class="dropdown-item"  href="#">ご連絡</a>
+          <a class="dropdown-item"  href={{ route('contact.index')}}>ご連絡</a>
         </div>
       </div>
-      <a class='nav-link text-white' href={{route('contact.index')}}>打刻</a>
-      <a class='nav-link text-white' href={{route('contact.create')}}>勤怠一覧</a>
+      <a class='nav-link text-white' href={{ route('work.edit',['work'=>$work->id]) }}>打刻</a>
+      <a class='nav-link text-white' href={{ route('work.index') }}>勤怠一覧</a>
+      <!-- <a class='nav-link text-white' href={{ route('worksystem.index') }}>システム設定</a> -->
 
       <!-- ここからログインユーザーの表示 -->
       <!-- layouts/app.blade.phpからコピー -->
@@ -71,5 +71,6 @@
     <!-- BootstrapのJS読み込み -->
     <!-- <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js" integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script> -->
     <script src="{{ asset('/js/work-edit.js') }}"></script>
+    <script src="{{ asset('/js/work-index.js') }}"></script>
   </body>
 </html>

--- a/backend/resources/views/works/edit.blade.php
+++ b/backend/resources/views/works/edit.blade.php
@@ -19,7 +19,7 @@
                             <div class="mb-3 mr-2">
                                 {{ Form::model('$work',['route' =>['work.update',$work]]) }}
                                     @method('PUT')
-                                    {{ Form::hidden('workstart',$today_date[4] )}}
+                                    {{ Form::hidden('workstart',$user[0]->work_system->fixed_workstart )}}
                                     {{ Form::submit('出勤', ['class' => 'work-start btn text-white pr-4 pl-4','id'=>'workstart-btn']) }}
                                 {{ Form::close() }}
                             </div>
@@ -31,7 +31,7 @@
                             <div class="mb-3">
                                 {{ Form::model('$work',['route' =>['work.update',$work]]) }}
                                     @method('PUT')
-                                    {{ Form::hidden('workend', $today_date[4])}}
+                                    {{ Form::hidden('workend', $user[0]->work_system->fixed_workend)}}
                                     {{ Form::submit('退勤', ['class' => 'btn text-white pr-4 pl-4 btn-secondary','id'=>'workend-btn']) }}
                                 {{ Form::close() }}
                                 @if($work->workend == '00:00:00')

--- a/backend/resources/views/works/index.blade.php
+++ b/backend/resources/views/works/index.blade.php
@@ -1,0 +1,31 @@
+@extends('layouts.works')
+
+@section('content')
+<h5 class="my-3 text-center">{{$date[0]}}年{{$date[1]}}月</h5>
+<table class="table table-bordered ">
+  <thead>
+    <tr class="work-index_title">
+      <th scope="col">日付</th>
+      <th scope="col">勤怠区分</th>
+      <th scope="col">出勤時刻</th>
+      <th scope="col">退勤時刻</th>
+      <th scope="col">休憩時間</th>
+      <th scope="col">合計勤務時間</th>
+      <th scope="col">備考</th>
+    </tr>
+  </thead>
+  <tbody>
+    @foreach($user_works as $work)
+      <tr id="targetTable">
+        <td>{{$work->day}}</th>
+        <td id="work-section">{{$work->work_section->section_name}}</td>
+        <td>{{$work->workstart}}</td>
+        <td>{{$work->workend}}</td>
+        <td>{{$work->breaktime}}</td>
+        <td>{{$work->total_worktime}}</td>
+        <td>{{$work->remark}}</td>
+      </tr>
+    @endforeach
+  </tbody>
+</table>
+@endsection

--- a/backend/resources/views/worksystems/index.blade.php
+++ b/backend/resources/views/worksystems/index.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.works')
+
+@section('content')
+<h5 class="my-3 text-center">システム設定</h5>
+<table class="table table-bordered ">
+  <thead>
+    <tr class="work-index_title">
+      <th scope="col">日付</th>
+      <th scope="col">勤怠区分</th>
+      <th scope="col">出勤時刻</th>
+
+    </tr>
+  </thead>
+  <tbody>
+    @foreach($user as $user_id)
+      <tr id="targetTable">
+        <td>{{$user_id->work_system->fixed_workstart}}</th>
+        <td id="work-section">{{$user_id->work_system->fixed_workstart}}</td>
+        <td>{{$user_id->work_system->fixed_workstart}}</td>
+      </tr>
+    @endforeach
+  </tbody>
+</table>
+@endsection

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -12,7 +12,7 @@
 */
 
 Route::get('/', function () {
-    return redirect('/contact');
+    return redirect('/work');
 });
 
 Auth::routes();
@@ -21,5 +21,6 @@ Auth::routes();
 Route::group(['middleware' => ['auth']], function () {
     Route::resource('contact', 'ContactController');
     Route::resource('work', 'WorkController')->only(['index','edit','update']);
+    Route::resource('worksystem', 'WorksystemController')->only(['index','edit','update']);
 });
 // Route::get('/home', 'HomeController@index')           ->name('home');


### PR DESCRIPTION
# what 
1.勤怠登録画面の作成
　・https://gyazo.com/9dd70c5fe21639d67e2ad0e89a29d901
2.勤怠登録機能(サーバサイド)の作成
　・テーブル作成
　・初期データ登録
3. 勤怠一覧ページの作成
　・https://gyazo.com/b4d28ed66c54624278f8cccc382318ee
# why
要件定義書の「2-1.勤怠登録」、「2-1.勤怠一覧表示」の要件を満たすため
