### PR TITLE
全ページの修正

### DIFF
--- a/backend/app/Contact.php
+++ b/backend/app/Contact.php
@@ -17,7 +17,7 @@ class Contact extends Model
     #created_atを任意のフォーマットで取得(投稿時間出力用)
     public function getCreatedAtAttribute($date)
     {
-        return Carbon::createFromFormat('Y-m-d H:i:s', $date)->format('H時i分');
+        return Carbon::createFromFormat('Y-m-d H:i:s', $date)->format('G時i分');
     }
 
     #updated_atを任意のフォーマットで取得(投稿日付出力用)

--- a/backend/app/Http/Controllers/Auth/LoginController.php
+++ b/backend/app/Http/Controllers/Auth/LoginController.php
@@ -38,8 +38,7 @@ class LoginController extends Controller
      */
     public function __construct()
     {
-        $this->middleware('guest')->except('/');
-    }
+        $this->middleware('guest')->except('/');    }
 
     #ログアウト時のページ遷移先
     protected function loggedOut(\Illuminate\Http\Request $request)

--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -12,6 +12,7 @@ use DateTime;                                  #DataTimeクラスの宣言
 use App\Work;                                  #Workクラスの宣言
 use Illuminate\Support\Facades\Auth;           #Authクラスの宣言
 use App\Work_system;                           #Work_systemクラスの宣言
+use DB;
 
 class RegisterController extends Controller
 {
@@ -111,19 +112,34 @@ class RegisterController extends Controller
                 $user->id;
             }
 
-            Work::create([
+
+            DB::table('works')->insert([
                 'year'            => $year,
                 'month'           => $month,
                 'day'             => $day,
-                'workstart'       => '00:00:00',
-                'workend'         => '00:00:00',
-                'breaktime'       => '00:00:00',
-                'total_worktime'  => '00:00:00',
+                'workstart'       => '',
+                'workend'         => '',
+                'breaktime'       => '',
+                'total_worktime'  => '',
                 'remark'          => 'なし',
                 'approval_flg'    => '1',
                 'work_section_id' => $work_section_id,
                 'user_id'         => $user->id,
             ]);
+
+            // Work::create([
+            //     'year'            => $year,
+            //     'month'           => $month,
+            //     'day'             => $day,
+            //     'workstart'       => '00:00:00',
+            //     'workend'         => '00:00:00',
+            //     'breaktime'       => '00:00:00',
+            //     'total_worktime'  => '00:00:00',
+            //     'remark'          => 'なし',
+            //     'approval_flg'    => '1',
+            //     'work_section_id' => $work_section_id,
+            //     'user_id'         => $user->id,
+            // ]);
         }
         return $user;
     }

--- a/backend/app/Http/Controllers/Auth/RegisterController.php
+++ b/backend/app/Http/Controllers/Auth/RegisterController.php
@@ -8,11 +8,8 @@ use App\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
-use DateTime;                                  #DataTimeクラスの宣言
 use App\Work;                                  #Workクラスの宣言
-use Illuminate\Support\Facades\Auth;           #Authクラスの宣言
 use App\Work_system;                           #Work_systemクラスの宣言
-use DB;
 
 class RegisterController extends Controller
 {
@@ -76,8 +73,8 @@ class RegisterController extends Controller
         $thisMonthLastDay = date('d', strtotime('last day of this month'));     #当月の最後の日付が出力
 
         $work_system = Work_system::create([
-            'fixed_workstart' => '00:00:00',
-            'fixed_workend'   => '00:00:00',
+            'fixed_workstart' => '09:00:00',
+            'fixed_workend'   => '18:00:00',
             'fixed_breaktime' => '01:00:00',
         ]);
 
@@ -112,34 +109,19 @@ class RegisterController extends Controller
                 $user->id;
             }
 
-
-            DB::table('works')->insert([
+            Work::create([
                 'year'            => $year,
                 'month'           => $month,
                 'day'             => $day,
-                'workstart'       => '',
-                'workend'         => '',
-                'breaktime'       => '',
-                'total_worktime'  => '',
+                'workstart'       => '00:00:00',
+                'workend'         => '00:00:00',
+                'breaktime'       => '00:00:00',
+                'total_worktime'  => '00:00:00',
                 'remark'          => 'なし',
                 'approval_flg'    => '1',
                 'work_section_id' => $work_section_id,
                 'user_id'         => $user->id,
             ]);
-
-            // Work::create([
-            //     'year'            => $year,
-            //     'month'           => $month,
-            //     'day'             => $day,
-            //     'workstart'       => '00:00:00',
-            //     'workend'         => '00:00:00',
-            //     'breaktime'       => '00:00:00',
-            //     'total_worktime'  => '00:00:00',
-            //     'remark'          => 'なし',
-            //     'approval_flg'    => '1',
-            //     'work_section_id' => $work_section_id,
-            //     'user_id'         => $user->id,
-            // ]);
         }
         return $user;
     }

--- a/backend/app/Http/Controllers/ContactController.php
+++ b/backend/app/Http/Controllers/ContactController.php
@@ -12,9 +12,7 @@
 namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Contact;                        #連絡事項クラスの宣言
-use DateTime;                           #DataTimeクラスの宣言
 use Illuminate\Support\Facades\Auth;    #ユーザークラスの宣言
-use App\Section;
 
 class ContactController extends Controller
 {
@@ -31,7 +29,13 @@ class ContactController extends Controller
         $user       = Auth::user();
         $contacts   = Contact::all();
         $today      = date("Ynj");
-        return view('contacts.index',['contacts'=> $contacts, 'user'=>$user,'today'=>$today,'today_date'=>$today_date]);
+
+        return view('contacts.index',[
+            'contacts'  => $contacts,
+            'user'      => $user,
+            'today'     => $today,
+            'today_date'=> $today_date
+        ]);
     }
 
     /**
@@ -82,7 +86,7 @@ class ContactController extends Controller
      */
     public function show($id)
     {
-        $user= Auth::user();
+        $user       = Auth::user();
         $contact_id = Contact::find($id);
         $contact    = new Contact;
         $today_date = $contact->date();
@@ -92,7 +96,13 @@ class ContactController extends Controller
         } else {
             $login_user_id = "";
         }
-        return view('contacts.show',['contact_id'=>$contact_id,'login_user_id'=>$login_user_id,'today_date'=>$today_date,'user'=>$user]);
+
+        return view('contacts.show',[
+            'contact_id'    => $contact_id,
+            'login_user_id' => $login_user_id,
+            'today_date'    => $today_date,
+            'user'          => $user
+        ]);
     }
 
     /**
@@ -107,6 +117,7 @@ class ContactController extends Controller
         $contact    = Contact::all();
         $contact    = new Contact;
         $today_date = $contact->date();
+        dd($contact_id->id,$contact_id);
         return view('contacts.edit',['contact_id' => $contact_id, 'contact'=> $contact,'today_date'=>$today_date]);
     }
 

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -37,32 +37,21 @@ class WorkController extends Controller
                             ->where('year', $year)
                             ->where('month', $month)
                             ->get();
+        #レコード取得出来なかった場合の例外処理
+        if (count($user_works) == 0){
+          $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
+          return view('layouts.errer', ['errer_messege' => $errer_messege]);
+        }
 
         #勤怠テーブルの承認フラグを取得
-        $approval_flg  = DB::table('works')
-                            ->select('approval_flg')
-                            ->where('user_id', '=', $login_user_id)
-                            ->where('year', $year)
-                            ->where('month', $month)
-                            ->groupBy('approval_flg')
-                            ->get();
-
-        // foreach($user_works as $work){
-        //     dd(date('H時i',strtotime($work->workstart)));
-        // }
-
-        //レコード取得出来なかった場合の例外処理
+        $work          = new Work;
+        $approval_flg  = $work->Login_User_Approvelflg_Get();
+        #レコード取得出来なかった場合の例外処理
         if (count($approval_flg) == 0){
             $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
             return view('layouts.errer', ['errer_messege' => $errer_messege]);
         }else{
             $approval_flg = $approval_flg[0]->approval_flg;
-        }
-
-        //レコード取得出来なかった場合の例外処理
-        if (count($user_works) == 0){
-            $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
-            return view('layouts.errer', ['errer_messege' => $errer_messege]);
         }
 
         #ログインユーザーの当日の勤怠ID取得(共通テンプレートで変数を使うため)
@@ -154,7 +143,6 @@ class WorkController extends Controller
                     ->Where('day', '=', $day);
             })
             ->get();
-
         #取得チェック
         if (count($work) == 0) {
             $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
@@ -168,12 +156,12 @@ class WorkController extends Controller
                         ->select('*')
                         ->where('id', $login_user_id)
                         ->get();
-
         #取得チェック
         if (count($user_record) == 0) {
             $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
             return view('layouts.errer', ['errer_messege' => $errer_messege]);
         }
+
         #システム日付を取得するために連絡事項クラスをインスタンス化
         $contact    = new Contact;
         $today_date = $contact->date();
@@ -185,6 +173,18 @@ class WorkController extends Controller
         $admin_user            = $user_information[1];       #管理者用
         $general_user          = $user_information[2];       #一般社員用
 
+        #勤怠テーブルの承認フラグを取得
+        $work_new          = new Work;
+        $approval_flg      = $work_new->Login_User_Approvelflg_Get();
+        #レコード取得出来なかった場合の例外処理
+        if (count($approval_flg) == 0){
+          $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
+          return view('layouts.errer', ['errer_messege' => $errer_messege]);
+        }else{
+            $approval_flg = $approval_flg[0]->approval_flg;
+        }
+
+        #勤怠の承認フラグを取得
         return view('works.edit',
         [
             'today_date'            => $today_date,
@@ -192,7 +192,8 @@ class WorkController extends Controller
             'user_record'           => $user_record,
             'login_user_authortyid' => $login_user_authortyid,
             'admin_user'            => $admin_user,
-            'general_user'          => $general_user
+            'general_user'          => $general_user,
+            'approval_flg'          => $approval_flg
         ]);
     }
 
@@ -218,10 +219,11 @@ class WorkController extends Controller
             $login_user_name = $user->UserName_Get($login_user_id);     #ログインユーザー名取得
             $login_fname     = $login_user_name->f_name;
             $login_rname     = $login_user_name->r_name;
-            $send_result     = $work_new->send_slack($this->url,$this->channel,$this->icon,$login_fname,$login_rname);
+            $slack_boby      = "出勤しました。";
+            $send_result     = $work_new->send_slack($this->url,$this->channel,$this->icon,$login_fname,$login_rname,$slack_boby);
             #送信結果取得
             if($send_result != 'ok'){
-                $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
+                $errer_messege = "slack自動送信に失敗しました。管理者にご連絡ください。";
                 return view('layouts.errer', ['errer_messege' => $errer_messege]);
             }
         } elseif($request->workend != null) {                    #退勤時
@@ -235,7 +237,6 @@ class WorkController extends Controller
             $fixed_work_start = new DateTime($user[0]->work_system->fixed_workstart);
             $breaktime        = new DateTime($user[0]->work_system->fixed_breaktime);
 
-
             #働いた時間の計算(時間 = 終了時間-開始時間-休憩時間)
             $total_time     = $fixed_work_end->diff($fixed_work_start);
             $total_time     = $total_time->h.':00';
@@ -244,9 +245,15 @@ class WorkController extends Controller
             $total_worktime = $total_worktime->h.':00';
 
             #DB更新
-            $work->total_worktime = $total_worktime;
+            $work->breaktime      = $user[0]->work_system->fixed_breaktime;
             $work->workend        = request('workend');
-            $work->save();
+            $work->total_worktime = $total_worktime;
+            $works_save           = $work->save();
+
+            if($works_save != true){
+              $errer_messege = "日付の更新に失敗しました。管理者にご連絡ください。";
+              return view('layouts.errer', ['errer_messege' => $errer_messege]);
+            }
 
         }else{
             $errer_messege = "登録に失敗しました。管理者にご連絡ください。";
@@ -259,17 +266,17 @@ class WorkController extends Controller
     {
         $contact    = new Contact;
         $today_date = $contact->date();
-        $year = $today_date[0];
-        $month = $today_date[1];
+        $year       = $today_date[0];
+        $month      = $today_date[1];
 
         #DB更新
         $execute_result = DB::table('works')
-                                ->where('user_id', request('login_user_id'))
-                                ->where('year', $year)
-                                ->where('month', $month)
-                                ->update([
-                                    'approval_flg' => request('approval_flg')
-                                ]);
+                          ->where('user_id', request('login_user_id'))
+                          ->where('year', $year)
+                          ->where('month', $month)
+                          ->update([
+                              'approval_flg' => request('approval_flg')
+                          ]);
         return redirect()->route('work.index');
     }
 

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -39,8 +39,8 @@ class WorkController extends Controller
                             ->get();
         #レコード取得出来なかった場合の例外処理
         if (count($user_works) == 0){
-          $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
-          return view('layouts.errer', ['errer_messege' => $errer_messege]);
+            $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
+            return view('layouts.errer', ['errer_messege' => $errer_messege]);
         }
 
         #勤怠テーブルの承認フラグを取得
@@ -178,8 +178,8 @@ class WorkController extends Controller
         $approval_flg      = $work_new->Login_User_Approvelflg_Get();
         #レコード取得出来なかった場合の例外処理
         if (count($approval_flg) == 0){
-          $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
-          return view('layouts.errer', ['errer_messege' => $errer_messege]);
+            $errer_messege = "レコード取得に失敗しました。管理者にご連絡ください。";
+            return view('layouts.errer', ['errer_messege' => $errer_messege]);
         }else{
             $approval_flg = $approval_flg[0]->approval_flg;
         }
@@ -251,8 +251,8 @@ class WorkController extends Controller
             $works_save           = $work->save();
 
             if($works_save != true){
-              $errer_messege = "日付の更新に失敗しました。管理者にご連絡ください。";
-              return view('layouts.errer', ['errer_messege' => $errer_messege]);
+                $errer_messege = "日付の更新に失敗しました。管理者にご連絡ください。";
+                return view('layouts.errer', ['errer_messege' => $errer_messege]);
             }
 
         }else{
@@ -271,12 +271,12 @@ class WorkController extends Controller
 
         #DB更新
         $execute_result = DB::table('works')
-                          ->where('user_id', request('login_user_id'))
-                          ->where('year', $year)
-                          ->where('month', $month)
-                          ->update([
-                              'approval_flg' => request('approval_flg')
-                          ]);
+                            ->where('user_id', request('login_user_id'))
+                            ->where('year', $year)
+                            ->where('month', $month)
+                            ->update([
+                                'approval_flg' => request('approval_flg')
+                            ]);
         return redirect()->route('work.index');
     }
 

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -30,6 +30,7 @@ class WorkController extends Controller
         $year          = $today_date[0];
         $month         = $today_date[1];
         $login_user_id = Auth::id();
+
         #ログインユーザーの勤怠を全て取得
         $user_works    = Work::with('work_section')
                             ->select('*')
@@ -118,31 +119,22 @@ class WorkController extends Controller
      */
     public function edit(Work $work)
     {
-        #DBから当日日付の勤怠レコード取得
+        #システム日付を取得するために連絡事項クラスをインスタンス化
+        $contact       = new Contact;
+        $today_date    = $contact->date();
+        $year          = $today_date[0];
+        $month         = $today_date[1];
+        $day           = $today_date[2];
         $login_user_id = Auth::id();
-        $work = Work::where('user_id', $login_user_id)
-            ->where(function ($query) {
-                $contact    = new Contact;
-                $today_date = $contact->date();
-                $year = $today_date[0];
-                $query
-                    ->Where('year', '=', $year);
-            })
-            ->where(function ($query) {
-                $contact    = new Contact;
-                $today_date = $contact->date();
-                $month = $today_date[1];
-                $query
-                    ->Where('month', '=', $month);
-            })
-            ->where(function ($query) {
-                $contact    = new Contact;
-                $today_date = $contact->date();
-                $day = $today_date[2];
-                $query
-                    ->Where('day', '=', $day);
-            })
-            ->get();
+
+        #DBから当日日付の勤怠レコード取得
+        $work          = DB::table('works')
+                            ->where('user_id', $login_user_id)
+                            ->where('year', $year)
+                            ->where('month', $month)
+                            ->where('day', $day)
+                            ->get();
+
         #取得チェック
         if (count($work) == 0) {
             $errer_messege = "日付取得に失敗しました。管理者にご連絡ください。";
@@ -163,8 +155,8 @@ class WorkController extends Controller
         }
 
         #システム日付を取得するために連絡事項クラスをインスタンス化
-        $contact    = new Contact;
-        $today_date = $contact->date();
+        // $contact    = new Contact;
+        // $today_date = $contact->date();
 
         #ログインユーザーの権限情報を取得(共通テンプレートで変数を使うため)
         $user                  = new User;
@@ -188,7 +180,7 @@ class WorkController extends Controller
         return view('works.edit',
         [
             'today_date'            => $today_date,
-            'work'                  => $work,
+            'work'                  => $work->id,
             'user_record'           => $user_record,
             'login_user_authortyid' => $login_user_authortyid,
             'admin_user'            => $admin_user,

--- a/backend/app/Http/Controllers/WorkController.php
+++ b/backend/app/Http/Controllers/WorkController.php
@@ -30,6 +30,7 @@ class WorkController extends Controller
         $year          = $today_date[0];
         $month         = $today_date[1];
         $login_user_id = Auth::id();
+        #ログインユーザーの勤怠を全て取得
         $user_works    = Work::with('work_section')
                             ->select('*')
                             ->where('user_id', '=', $login_user_id)
@@ -45,6 +46,10 @@ class WorkController extends Controller
                             ->where('month', $month)
                             ->groupBy('approval_flg')
                             ->get();
+
+        // foreach($user_works as $work){
+        //     dd(date('H時i',strtotime($work->workstart)));
+        // }
 
         //レコード取得出来なかった場合の例外処理
         if (count($approval_flg) == 0){

--- a/backend/app/Http/Controllers/WorkSystemController.php
+++ b/backend/app/Http/Controllers/WorkSystemController.php
@@ -39,6 +39,7 @@ class WorkSystemController extends Controller
         $login_user_authortyid = $user_information[0];
         $admin_user            = $user_information[1];       #管理者用
         $general_user          = $user_information[2];       #一般社員用
+
         return view('worksystems.index', [
             'loginuser_record'      => $loginuser_record,
             'work'                  => $work_id,
@@ -90,17 +91,17 @@ class WorkSystemController extends Controller
     {
         // $worksystem = new Work_system;
         $worksystem_id = Work_system::find($id);
-        $workstart  = $worksystem_id->fixed_workstart;
-        $workend    = $worksystem_id->fixed_workend;
-        $breaktime  = $worksystem_id->fixed_breaktime;
+        $workstart     = $worksystem_id->fixed_workstart;
+        $workend       = $worksystem_id->fixed_workend;
+        $breaktime     = $worksystem_id->fixed_breaktime;
 
         #勤怠時間のフォーマット変更(HH:MM:SS->HH時MM分)
-        $worksystem = new Work_system;
-        $worktimes  = $worksystem->work_time_format($workstart,$workend,$breaktime);
+        $worksystem    = new Work_system;
+        $worktimes     = $worksystem->work_time_format($workstart,$workend,$breaktime);
 
         #ログインユーザーの当日の勤怠ID取得(共通テンプレートで勤怠idが使える様にするため)
-        $work    = new Work;
-        $work_id = $work->work_id_get();
+        $work          = new Work;
+        $work_id       = $work->work_id_get();
 
         #ログインユーザーの権限情報を取得(共通テンプレートで変数を使うため)
         $user                  = new User;
@@ -111,8 +112,8 @@ class WorkSystemController extends Controller
         // dd($login_user_authortyid,$admin_user);
 
         return view('worksystems.edit',[
-            'worksystem_id' => $worksystem_id,
-            'worktimes'     => $worktimes,
+            'worksystem_id'         => $worksystem_id,
+            'worktimes'             => $worktimes,
             'work'                  => $work_id,
             'login_user_authortyid' => $login_user_authortyid,
             'admin_user'            => $admin_user,

--- a/backend/app/Http/Controllers/WorkSystemController.php
+++ b/backend/app/Http/Controllers/WorkSystemController.php
@@ -96,7 +96,7 @@ class WorkSystemController extends Controller
 
         #勤怠時間のフォーマット変更(HH:MM:SS->HH時MM分)
         $worksystem = new Work_system;
-        $worktimes = $worksystem->work_time_format($workstart,$workend,$breaktime);
+        $worktimes  = $worksystem->work_time_format($workstart,$workend,$breaktime);
 
         #ログインユーザーの当日の勤怠ID取得(共通テンプレートで勤怠idが使える様にするため)
         $work    = new Work;

--- a/backend/app/Http/Controllers/WorkSystemController.php
+++ b/backend/app/Http/Controllers/WorkSystemController.php
@@ -133,7 +133,6 @@ class WorkSystemController extends Controller
         $worksystem = Work_system::find($id);
         $worksystem->fixed_workstart = request('fixed_workstart');
         $worksystem->fixed_workend   = request('fixed_workend');
-        $worksystem->fixed_breaktime = request('fixed_breaktime');
         $worksystem->save();
         return redirect()->route('worksystem.index');
     }

--- a/backend/app/Http/Controllers/Work_approvelController.php
+++ b/backend/app/Http/Controllers/Work_approvelController.php
@@ -61,7 +61,7 @@ class Work_approvelController extends Controller
 
     public function update(Request $request,$user_id)
     {
-        //権限者が承認したらworkテーブルのapprovel_flgを3に更新する
+        //管理者が承認or差し戻し時にworkテーブルのapprovel_flgを更新する
         $approval_flg   = request('approval_flg');
         $work           = new work;
         $execute_result = $work->approvel_update($user_id,$approval_flg);

--- a/backend/app/Work.php
+++ b/backend/app/Work.php
@@ -92,6 +92,25 @@ class Work extends Model
     }
 
     #----------------------------------------------------------------
+    #  #勤怠テーブルの承認フラグを取得
+    #----------------------------------------------------------------
+    public function Login_User_Approvelflg_Get()
+    {
+        $contact    = new Contact;
+        $today_date = $contact->date();
+        $year       = $today_date[0];
+        $month      = $today_date[1];
+        $login_user_id = Auth::id();
+        $approval_flg  = DB::table('works')
+                            ->select('approval_flg')
+                            ->where('user_id', '=', $login_user_id)
+                            ->where('year', $year)
+                            ->where('month', $month)
+                            ->groupBy('approval_flg')
+                            ->get();
+        return $approval_flg;
+    }
+    #----------------------------------------------------------------
     #  管理者が承認したらworkテーブルのapproval_flgを承認済に設定
     #----------------------------------------------------------------
     public function approvel_update($user_id,$approval_flg)
@@ -140,14 +159,16 @@ class Work extends Model
     #----------------------------------------------------------------
     #  勤怠を押下時にslackへ勤怠連絡をする
     #----------------------------------------------------------------
-    public function send_slack($slack_url,$slack_channel,$slack_icon,$login_fname,$login_rname)
+    public function send_slack($slack_url,$slack_channel,$slack_icon,$login_fname,$login_rname,$slack_boby)
     {
+
+
         $url     = $slack_url;
         $message = [
-            "channel"    => $slack_channel,
-            "username"   => "出勤連絡",
-            "icon_emoji" => $slack_icon,
-            "text"       => $login_fname.$login_rname.'出勤しました',
+            "channel"    => $slack_channel,                       #チャンネル名
+            "username"   => $login_fname.$login_rname,            #投稿者名
+            "icon_emoji" => $slack_icon,                          #アイコン
+            "text"       => $slack_boby,                          #本文
         ];
 
         #セッション初期化

--- a/backend/app/Work.php
+++ b/backend/app/Work.php
@@ -161,8 +161,6 @@ class Work extends Model
     #----------------------------------------------------------------
     public function send_slack($slack_url,$slack_channel,$slack_icon,$login_fname,$login_rname,$slack_boby)
     {
-
-
         $url     = $slack_url;
         $message = [
             "channel"    => $slack_channel,                       #チャンネル名
@@ -190,5 +188,27 @@ class Work extends Model
         #セッション終了
         curl_close($ch);
         return $send_result;
+    }
+
+    #----------------------------------------------------------------
+    #  勤怠時間を任意のフォーマットに変更
+    #  HH:MM:SS->HH時MM分
+    #  HH:MM:SS->HH時間
+    #----------------------------------------------------------------
+    public function work_time_format($workstart,$workend,$breaktime,$total_worktime)
+    {
+        $workstart_format      = date('G時i分',strtotime($workstart));
+        $workend_format        = date('G時i分',strtotime($workend));
+        $breaktime_format      = date('G時間',strtotime($breaktime));
+        $total_worktime_format = date('G時間',strtotime($total_worktime));
+        // dd($workstart_format,$workend_format,$breaktime_format,$total_worktime_format);
+        $worktimes_format_edit = [
+            'workstart'      => $workstart_format,
+            'workend'        => $workend_format,
+            'breaktime'      => $breaktime_format,
+            'total_worktime' => $total_worktime_format,
+        ];
+        // dd($worktime_format_edit['workstart']);
+        return $worktimes_format_edit;
     }
 }

--- a/backend/resources/views/home.blade.php
+++ b/backend/resources/views/home.blade.php
@@ -13,7 +13,6 @@
                             {{ session('status') }}
                         </div>
                     @endif
-
                     You are logged in!
                 </div>
             </div>

--- a/backend/resources/views/layouts/app.blade.php
+++ b/backend/resources/views/layouts/app.blade.php
@@ -25,22 +25,23 @@
   <div id="app">
     <nav class="navbar navbar-expand-md navbar-light shadow-sm">
       <div class="container">
-        <form method="post" action="{{ route('login') }}">
-          @csrf
-          <input type="hidden" name="email" value="a@a">
-          <input type="hidden" name="password" value="aaaaaaaa">
-          <button type="submit" class="btn text-white nav-link">管理者用ログイン</button>
-        </form>
-        <form method="post" action="{{ route('login') }}">
-          @csrf
-          <input type="hidden" name="email" value="aa@aa">
-          <input type="hidden" name="password" value="aaaaaaaa">
-          <button type="submit" class="btn text-white nav-link">一般社員用ログイン</button>
-        </form>
-        <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
-          <span class="navbar-toggler-icon"></span>
-        </button>
-
+        <div class="row">
+          <form method="post" action="{{ route('login') }}">
+            @csrf
+            <input type="hidden" name="email" value="a@a">
+            <input type="hidden" name="password" value="aaaaaaaa">
+            <button type="submit" class="btn text-white nav-link">管理者用ログイン</button>
+          </form>
+          <form method="post" action="{{ route('login') }}">
+            @csrf
+            <input type="hidden" name="email" value="aa@aa">
+            <input type="hidden" name="password" value="aaaaaaaa">
+            <button type="submit" class="btn text-white nav-link">一般社員用ログイン</button>
+          </form>
+          <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="{{ __('Toggle navigation') }}">
+            <span class="navbar-toggler-icon"></span>
+          </button>
+        </div>
         <!-- <div class="collapse navbar-collapse" id="navbarSupportedContent">
           <ul class="navbar-nav ml-auto">
             @guest

--- a/backend/resources/views/layouts/errer.blade.php
+++ b/backend/resources/views/layouts/errer.blade.php
@@ -1,4 +1,5 @@
-@extends('layout')
+@extends('layouts.layout')
+@include('layouts.header')
 
 @section('content')
 <div class="container">

--- a/backend/resources/views/layouts/errer.blade.php
+++ b/backend/resources/views/layouts/errer.blade.php
@@ -3,16 +3,16 @@
 @section('content')
 <div class="container">
   <div class="row justify-content-center">
-      <div class="col-md-8">
-          <div class="card">
-              <div class="card-header text-center" style="background:#e9e1de;">{{('取得エラー') }}</div>
-                <div class="card-body text-center">
-                  @php
-                    echo $errer_messege;
-                  @endphp
-                </div>
-          </div>
+    <div class="col-md-8">
+      <div class="card">
+        <div class="card-header text-center" style="background:#e9e1de;">{{('取得エラー') }}</div>
+        <div class="card-body text-center">
+          @php
+            echo $errer_messege;
+          @endphp
+        </div>
       </div>
+    </div>
   </div>
 </div>
 @endsection

--- a/backend/resources/views/work_approvel/workindex.blade.php
+++ b/backend/resources/views/work_approvel/workindex.blade.php
@@ -46,12 +46,23 @@
       </tr>
     @endforeach
       <tr class="text-center work-list">
-        <td colspan="7">
-          {{ Form::model(['route' =>['work_approvel.update',$user_list->id]]) }}
+        <td></td>
+        <td></td>
+        <td></td>
+        <td colspan="2">
+          <div class= "row">
+            {{ Form::model(['route' =>['work_approvel.update',$user_list->id]]) }}
+              {{ Form::hidden('approval_flg',4 )}}
+              {{ Form::submit('差し戻し', ['class' => 'btn text-white mr-4 btn-secondary ']) }}
+            {{ Form::close() }}
+            {{ Form::model(['route' =>['work_approvel.update',$user_list->id]]) }}
               {{ Form::hidden('approval_flg',3 )}}
-              {{ Form::submit('承認', ['class' => 'btn text-white pr-4 pl-4 submit-approval','id'=>'workstart-btn']) }}
-          {{ Form::close() }}
+              {{ Form::submit('承認', ['class' => 'btn text-white pr-4 pl-4 submit-approval']) }}
+            {{ Form::close() }}
+          </div>
         </td>
+      <td></td>
+      <td></td>
       </tr>
   </tbody>
 

--- a/backend/resources/views/work_approvel/workindex.blade.php
+++ b/backend/resources/views/work_approvel/workindex.blade.php
@@ -20,12 +20,28 @@
   <tbody>
     @foreach($work_list as $work)
       <tr class="table-bordered">
-        <td>{{$work->day}}</tb>
+      <td>{{$work->day}}</tb>
         <td id="work-section">{{$work->work_section->section_name}}</td>
-        <td>{{$work->workstart}}</td>
-        <td>{{$work->workend}}</td>
-        <td>{{$work->breaktime}}</td>
-        <td>{{$work->total_worktime}}</td>
+        @if($work->workstart == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時i分',strtotime($work->workstart)) }}</td>
+        @endif
+        @if($work->workend == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時i分',strtotime($work->workend)) }}</td>
+        @endif
+        @if($work->breaktime == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時間',strtotime($work->breaktime))}}</td>
+        @endif
+        @if($work->total_worktime == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時間',strtotime($work->total_worktime)) }}</td>
+        @endif
         <td >{{$work->remark}}</td>
       </tr>
     @endforeach

--- a/backend/resources/views/works/edit.blade.php
+++ b/backend/resources/views/works/edit.blade.php
@@ -16,32 +16,42 @@
               {{$today_date[4]}}
             </h1>
           </div>
-          <div class="d-flex justify-content-center attendance">
-            <div class="mb-3 mr-2">
-              {{ Form::model('$work',['route' =>['work.update',$work]]) }}
-                @method('PUT')
-                {{ Form::hidden('workstart',$user_record[0]->work_system->fixed_workstart )}}
-                {{ Form::submit('出勤', ['class' => 'work-start btn text-white pr-4 pl-4','id'=>'workstart-btn']) }}
-              {{ Form::close() }}
-            </div>
-            @if($work->workstart == '00:00:00')
-              <div hidden id="work-start_hours"></div>
-            @else
-              <div hidden id="work-start_hours">{{$work->workstart}}</div>
-            @endif
-            <div class="mb-3">
-              {{ Form::model('$work',['route' =>['work.update',$work]]) }}
-                @method('PUT')
-                {{ Form::hidden('workend', $user_record[0]->work_system->fixed_workend)}}
-                {{ Form::submit('退勤', ['class' => 'btn text-white pr-4 pl-4 btn-secondary','id'=>'workend-btn']) }}
-              {{ Form::close() }}
-              @if($work->workend == '00:00:00')
-                <div hidden id="work-end_hours"></div>
+          @if($approval_flg =='1')
+            <div class="d-flex justify-content-center attendance">
+              <div class="mb-3 mr-2">
+                {{ Form::model('$work',['route' =>['work.update',$work]]) }}
+                  @method('PUT')
+                  {{ Form::hidden('workstart',$user_record[0]->work_system->fixed_workstart )}}
+                  {{ Form::submit('出勤', ['class' => 'work-start btn text-white pr-4 pl-4','id'=>'workstart-btn']) }}
+                {{ Form::close() }}
+              </div>
+              @if($work->workstart == '00:00:00')
+                <div hidden id="work-start_hours"></div>
               @else
-                <div hidden id="work-end_hours">{{$work->workend}}</div>
+                <div hidden id="work-start_hours">{{$work->workstart}}</div>
               @endif
+              <div class="mb-3">
+                {{ Form::model('$work',['route' =>['work.update',$work]]) }}
+                  @method('PUT')
+                  {{ Form::hidden('workend', $user_record[0]->work_system->fixed_workend)}}
+                  {{ Form::submit('退勤', ['class' => 'btn text-white pr-4 pl-4 btn-secondary','id'=>'workend-btn']) }}
+                {{ Form::close() }}
+                @if($work->workend == '00:00:00')
+                  <div hidden id="work-end_hours"></div>
+                @else
+                  <div hidden id="work-end_hours">{{$work->workend}}</div>
+                @endif
+              </div>
             </div>
-          </div>
+          @elseif($approval_flg =='2')
+            <div class="d-flex justify-content-center attendance">
+              <button type="button" class="btn btn-secondary pr-4 pl-4">勤怠申請中</button>
+            </div>
+          @elseif($approval_flg =='3')
+            <div class="d-flex justify-content-center attendance">
+              <button type="button" class="btn btn-secondary pr-4 pl-4">勤怠承認されました(今月分)</button>
+            </div>
+          @endif
         </div>
       </div>
     </div>

--- a/backend/resources/views/works/edit.blade.php
+++ b/backend/resources/views/works/edit.blade.php
@@ -51,6 +51,10 @@
             <div class="d-flex justify-content-center attendance">
               <button type="button" class="btn btn-secondary pr-4 pl-4">勤怠承認されました(今月分)</button>
             </div>
+          @elseif($approval_flg =='4')
+            <div class="d-flex justify-content-center attendance">
+              <button type="button" class="btn btn-secondary pr-4 pl-4">勤怠を修正してください(今月分)</button>
+            </div>
           @endif
         </div>
       </div>

--- a/backend/resources/views/works/index.blade.php
+++ b/backend/resources/views/works/index.blade.php
@@ -47,7 +47,7 @@
       </tr>
     @endforeach
 
-    @if($approval_flg == 1 or $approval_flg == 4)
+    @if($approval_flg == '1' or $approval_flg == '4')
       <tr class="text-center work-list">
         <td colspan="7">
           {{ Form::model(['route' =>['work.request']]) }}
@@ -57,13 +57,13 @@
           {{ Form::close() }}
         </td>
       </tr>
-    @elseif(  $approval_flg == 2)
+    @elseif($approval_flg == '2')
       <tr class="text-center work-list">
         <td colspan="7">
           <button type="button" class="btn btn-secondary pr-4 pl-4">申請中</button>
         </td>
       </tr>
-    @elseif($approval_flg == 3)
+    @elseif($approval_flg == '3')
       <tr class="text-center work-list">
         <td colspan="7">
           <button type="button" class="btn btn-secondary pr-4 pl-4">承認済</button>

--- a/backend/resources/views/works/index.blade.php
+++ b/backend/resources/views/works/index.blade.php
@@ -3,6 +3,9 @@
 @include('layouts.header_workbar')
 @section('content')
 <h5 class="my-3 text-center">{{$year}}年{{$month}}月</h5>
+@if($approval_flg == 4)
+  <h5 class="my-3 text-danger text-center">管理者から差し戻されました。</h5>
+@endif
 <table class="table">
   <thead>
     <tr class="work-index_title table-bordered">
@@ -44,7 +47,7 @@
       </tr>
     @endforeach
 
-    @if($approval_flg == 1)
+    @if($approval_flg == 1 or $approval_flg == 4)
       <tr class="text-center work-list">
         <td colspan="7">
           {{ Form::model(['route' =>['work.request']]) }}

--- a/backend/resources/views/works/index.blade.php
+++ b/backend/resources/views/works/index.blade.php
@@ -16,6 +16,7 @@
       <th scope="col">休憩時間</th>
       <th scope="col">合計勤務時間</th>
       <th scope="col">備考</th>
+      <th scope="col">編集</th>
     </tr>
   </thead>
   <tbody>
@@ -43,7 +44,12 @@
         @else
           <td>{{ date('G時間',strtotime($work->total_worktime)) }}</td>
         @endif
-        <td >{{$work->remark}}</td>
+        <td>{{$work->remark}}</td>
+        <td>
+          <a href={{ route('work.show',['work'=>$work->id]) }}>
+            編集
+          </a>
+        </td>
       </tr>
     @endforeach
 

--- a/backend/resources/views/works/index.blade.php
+++ b/backend/resources/views/works/index.blade.php
@@ -20,10 +20,26 @@
       <tr class="table-bordered">
         <td>{{$work->day}}</tb>
         <td id="work-section">{{$work->work_section->section_name}}</td>
-        <td>{{$work->workstart}}</td>
-        <td>{{$work->workend}}</td>
-        <td>{{$work->breaktime}}</td>
-        <td>{{$work->total_worktime}}</td>
+        @if($work->workstart == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時i分',strtotime($work->workstart)) }}</td>
+        @endif
+        @if($work->workend == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時i分',strtotime($work->workend)) }}</td>
+        @endif
+        @if($work->breaktime == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時間',strtotime($work->breaktime))}}</td>
+        @endif
+        @if($work->total_worktime == '00:00:00')
+          <td></td>
+        @else
+          <td>{{ date('G時間',strtotime($work->total_worktime)) }}</td>
+        @endif
         <td >{{$work->remark}}</td>
       </tr>
     @endforeach

--- a/backend/resources/views/works/show.blade.php
+++ b/backend/resources/views/works/show.blade.php
@@ -1,0 +1,125 @@
+@extends('layouts.layout')
+@include('layouts.header')
+@include('layouts.header_workbar')
+@section('content')
+<table class="table work-system">
+{{ Form::model('$date_work_record ',['route' =>['work.store',$date_work_record->id ]]) }}
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title">日付</th>
+    <td>{{ $date_work_record->day }}日</tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title">勤怠区分</th>
+    <td>
+      @if($date_work_record->work_section->section_name == '出勤')
+        {{ Form::select('work_section_id', [
+            '1' =>$date_work_record->work_section->section_name,
+            '2' => '法定休日',
+            '3' => '法定外休日',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @elseif($date_work_record->work_section->section_name == '法定休日')
+        {{ Form::select('work_section_id', [
+            '2' =>$date_work_record->work_section->section_name,
+            '1' => '出勤',
+            '3' => '法定外休日',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @else
+        {{ Form::select('work_section_id', [
+            '3' => $date_work_record->work_section->section_name,
+            '1' => '出勤',
+            '2' => '法定休日',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @endif
+    </tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title ">出勤時刻</th>
+    <td>
+      @if($worktimes_format_edit['workstart'] == '9時00分')
+        {{ Form::select('workstart', [
+            $date_work_record->workstart =>$worktimes_format_edit['workstart'],
+            '10:00' => '10時00分',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @elseif($worktimes_format_edit['workstart'] == '10時00分')
+        {{ Form::select('workstart', [
+            $date_work_record->workstart =>$worktimes_format_edit['workstart'],
+            '9:00' => '9時00分',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @endif
+    </tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title ">退勤時刻</th>
+    <td>
+      @if($worktimes_format_edit['workend'] == '18時00分')
+        {{ Form::select('workend', [
+            $date_work_record->workend =>$worktimes_format_edit['workend'],
+            '19:00' => '19時00分',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @elseif($worktimes_format_edit['workend'] == '19時00分')
+        {{ Form::select('workend', [
+            $date_work_record->workend =>$worktimes_format_edit['workend'],
+            '18:00' => '18時00分',
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
+      @endif
+    </tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title ">休憩時刻</th>
+    <td>
+      {{ $worktimes_format_edit['breaktime'] }}
+    </tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title ">合計勤務時刻</th>
+    <td>
+    @if($worktimes_format_edit['total_worktime'] == '8時間')
+      {{ Form::select('total_worktime', [
+          $date_work_record->total_worktime =>$worktimes_format_edit['total_worktime'],
+          '9:00' => '9時間',
+          '10:00' => '10時間',
+        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+      }}
+    @elseif($worktimes_format_edit['total_worktime'] == '9時間')
+      {{ Form::select('total_worktime', [
+          $date_work_record->total_worktime =>$worktimes_format_edit['total_worktime'],
+          '8:00' => '8時間',
+          '10:00' => '10時間',
+        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+      }}
+    @elseif($worktimes_format_edit['total_worktime'] == '10時間')
+      {{ Form::select('total_worktime', [
+          $date_work_record->total_worktime =>$worktimes_format_edit['total_worktime'],
+          '8:00' => '8時間',
+          '9:00' => '9時間',
+        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+      }}
+    @endif
+    </tb>
+  </tr>
+  <tr class="table-bordered">
+    <th scope="row"  class="work-index_title ">備考</th>
+    <td>
+      {{ Form::textarea('remark',$date_work_record->remark)}}
+    </tb>
+  </tr>
+
+    <tr>
+      <th class="pr-5"></th>
+      <td class="text-left">
+        <a href={{ route('work.index') }}>
+          <button type="button" class="btn btn-secondary pr-4 pl-4">戻る</button>
+        </a>
+        {{ Form::submit('更新', ['class' => 'btn text-white pr-4 pl-4 work-system_time']) }}
+      </td>
+    </tr>
+  </table>
+{{ Form::close() }}
+@endsection

--- a/backend/resources/views/worksystems/edit.blade.php
+++ b/backend/resources/views/worksystems/edit.blade.php
@@ -46,22 +46,7 @@
     </tr>
     <tr class="table-bordered">
       <th scope="row"  class="work-index_title">休憩時間</th>
-      <td>
-      @if ($worktimes[2] == '1時間')
-        {{ Form::select('fixed_breaktime',[
-          $worksystem_id->fixed_breaktime => $worktimes[2],
-          '2:00'  => '2時間',
-          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])
-        }}
-      @endif
-      @if ($worktimes[2] == '2時間')
-        {{ Form::select('fixed_breaktime',[
-          $worksystem_id->fixed_breaktime => $worktimes[2],
-          '1:00'  => '1時間',
-          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])
-        }}
-      @endif
-      </tb>
+      <td> {{ $worktimes[2] }} </tb>
     </tr>
 
   <tr>

--- a/backend/resources/views/worksystems/edit.blade.php
+++ b/backend/resources/views/worksystems/edit.blade.php
@@ -13,13 +13,15 @@
         {{ Form::select('fixed_workstart', [
           $worksystem_id->fixed_workstart  => $worktimes[0],
           '10:00' => '10時00分',
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
       @endif
       @if ($worktimes[0] == '10時00分')
         {{ Form::select('fixed_workstart', [
           $worksystem_id->fixed_workstart  => $worktimes[0],
           '9:00'  => '9時00分',
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
       @endif
       </tb>
     </tr>
@@ -30,13 +32,15 @@
         {{ Form::select('fixed_workend', [
           $worksystem_id->fixed_workend  =>$worktimes[1],
           '19:00' => '19時00分'
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
       @endif
       @if ($worktimes[1] == '19時00分')
         {{ Form::select('fixed_workend', [
           $worksystem_id->fixed_workend  => $worktimes[1],
           '18:00' => '18時00分'
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2 '])
+        }}
       @endif
       </tb>
     </tr>
@@ -47,13 +51,15 @@
         {{ Form::select('fixed_breaktime',[
           $worksystem_id->fixed_breaktime => $worktimes[2],
           '2:00'  => '2時間',
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])
+        }}
       @endif
       @if ($worktimes[2] == '2時間')
         {{ Form::select('fixed_breaktime',[
           $worksystem_id->fixed_breaktime => $worktimes[2],
           '1:00'  => '1時間',
-        ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])}}
+          ], null, ['class' => 'pt-2 pb-2 pr-2 pl-2'])
+        }}
       @endif
       </tb>
     </tr>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -12,8 +12,9 @@ Auth::routes();
 Route::group(['middleware' => ['auth']], function () {
     #一般社員ページ
     Route::resource('contact', 'ContactController');
-    Route::resource('work', 'WorkController')->only(['index','edit','update']);
+    Route::resource('work', 'WorkController')->only(['index','edit','update','show']);
     Route::post('work', 'WorkController@workrequest')->name('work.request');
+    Route::post('work/{work}', 'WorkController@store')->name('work.store');
     Route::resource('worksystem', 'WorksystemController')->only(['index','edit','update']);
     #管理者専用ページ
     Route::get('approvel', 'Work_approvelController@index')->name('user_approvel.index')->middleware('check_approvel');


### PR DESCRIPTION
# what 
1.勤怠表示フォーマットの変更 (HH:MM:SS→HH時SS分)
2.ユーザー新規登録時に勤怠出退勤時間を固定に設定(開始:9時、終了: 18時)
3.勤怠申請時に出退勤ボタンの表示変更
申請時: https://gyazo.com/0878ebb81a3d09d2b3c370adaee9a57f
差し戻し時: https://gyazo.com/df9130cb52ccc3ce4d01369261124096
4.申請勤怠を管理者が差し戻し出来る様に実装
5.当月分の勤怠を修正出来る様に実装
https://gyazo.com/5ce76de9a806bd5c2c69b9277d084f2c

# why
1.HH時SS分にした方が見やすいため
2.基本的に勤怠時間は会社独自のルールなので、ルールに従うため
3.申請中に勤怠を更新できない様にするため
4.修正して欲しい時に差し戻しをしたいため
5.管理者から差し戻された場合に修正出来る様にするため